### PR TITLE
notification-trashcan-icon

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3114,6 +3114,9 @@ class Block {
             ) {
                 if (this.activity.trashcan.isVisible) {
                     this.blocks.sendStackToTrash(this);
+                    activity.textMsg(
+                        _("You can restore deleted blocks from the trash with the Restore From Trash button."), 3000
+                    );                   
                 }
             } else {
                 // Otherwise, process move.


### PR DESCRIPTION
Issue #4112
Issue Bug 
Previously the deletion notification was not shown when the blocks were drag and dropped to trash icon. Now it is fixed.

This is my first PR here in Music Blocks. I am still new so pardon me if I did something wrong. 